### PR TITLE
Add support for %p

### DIFF
--- a/lib_logging/src/debug_printf.c
+++ b/lib_logging/src/debug_printf.c
@@ -14,7 +14,7 @@ static void reverse_array(char buf[], unsigned size)
   int begin = 0;
   int end = size - 1;
   int tmp;
-  for (;begin < end;begin++,end--) {
+  for (;begin < end; begin++,end--) {
     tmp = buf[begin];
     buf[begin] = buf[end];
     buf[end] = tmp;
@@ -22,7 +22,8 @@ static void reverse_array(char buf[], unsigned size)
 }
 
 static int itoa(unsigned n, char *buf, unsigned base, int fill)
-{ static const char digits[] = "0123456789ABCDEF";
+{
+  static const char digits[] = "0123456789ABCDEF";
   unsigned i = 0;
 
   if (n == 0)
@@ -36,7 +37,7 @@ static int itoa(unsigned n, char *buf, unsigned base, int fill)
     fill--;
     n = next;
   }
-  for (;fill > 0;fill--) {    
+  for (;fill > 0; fill--) {
     buf[i] = '0';
     i++;
   }
@@ -64,7 +65,7 @@ void debug_printf(char * fmt, ...)
   va_list args;
 
   va_start(args,fmt);
-  marker = fmt;	
+  marker = fmt;
   char *p = buf;
   while (*fmt) {
     if (p > end) {
@@ -72,52 +73,51 @@ void debug_printf(char * fmt, ...)
       _write(FD_STDOUT, buf, p - buf);
       p = buf;
     }
-    switch (*fmt) 
-      {
-      case '%':
-        fmt++;
-	switch (*(fmt)) 
-	  {
-	  case 'd':
-	    intArg = va_arg(args, int);
-            if (intArg < 0) {
-              *p++ = '-';
-              intArg = -intArg;
-            }
-            p += itoa(intArg, p, 10, 0);
-            break;
-	  case 'u':
-	    uintArg = va_arg(args, int);
-            p += itoa(uintArg, p, 10, 0);
-            break;
-	  case 'x':
-	    uintArg = va_arg(args, int);
-            p += itoa(uintArg, p, 16, 0);
-	    break;
-	  case 'c':
-	    intArg = va_arg(args, int);
-            *p++ = intArg;
-	    break;
-	  case 's':
-	    strArg = va_arg(args, char *);
-            int len = strlen(strArg);
-            if (len > (end - buf)) {
-              // flush
-              _write(FD_STDOUT, buf, p - buf);
-              p = buf;
-            }
-            if (len > (end - buf))
-              len = end - buf;
-            memcpy(p, strArg, len);
-            p += len;
-	    break;
-          default:
-            break;
-	  }
-	break;
+    switch (*fmt) {
+    case '%':
+      fmt++;
+      switch (*(fmt)) {
+      case 'd':
+        intArg = va_arg(args, int);
+        if (intArg < 0) {
+          *p++ = '-';
+          intArg = -intArg;
+        }
+        p += itoa(intArg, p, 10, 0);
+        break;
+      case 'u':
+        uintArg = va_arg(args, int);
+        p += itoa(uintArg, p, 10, 0);
+        break;
+      case 'x':
+        uintArg = va_arg(args, int);
+        p += itoa(uintArg, p, 16, 0);
+        break;
+      case 'c':
+        intArg = va_arg(args, int);
+        *p++ = intArg;
+        break;
+      case 's':
+        strArg = va_arg(args, char *);
+        int len = strlen(strArg);
+        if (len > (end - buf)) {
+                // flush
+          _write(FD_STDOUT, buf, p - buf);
+          p = buf;
+        }
+        if (len > (end - buf))
+          len = end - buf;
+        memcpy(p, strArg, len);
+        p += len;
+        break;
       default:
-        *p++ = *fmt;
+        break;
       }
+      break;
+
+    default:
+      *p++ = *fmt;
+    }
     fmt++;
   }
   _write(FD_STDOUT, buf, p - buf);

--- a/lib_logging/src/debug_printf.c
+++ b/lib_logging/src/debug_printf.c
@@ -89,6 +89,7 @@ void debug_printf(char * fmt, ...)
         uintArg = va_arg(args, int);
         p += itoa(uintArg, p, 10, 0);
         break;
+      case 'p':
       case 'x':
         uintArg = va_arg(args, int);
         p += itoa(uintArg, p, 16, 0);


### PR DESCRIPTION
The %p format is commonly used in the lwip code and so it is good for pointer printing to be supported. I've added it as the same as %x printing. However, I first cleaned up the mix of tabs and spaces.