### PR TITLE
Wrapped test script in if__name__==__main__

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -1,24 +1,25 @@
 #!/usr/bin/env python
 import xmostest
 
-xmostest.init()
+if __name__ == "__main__":
+	xmostest.init()
 
-xmostest.register_group("lib_logging",
-                        "simple_tests",
-                        "Simple functionality tests",
-"""
-There is currently just one test for this library. It is a simple test that
-uses the various format specifiers and checks the output.
-""")
+	xmostest.register_group("lib_logging",
+	                        "simple_tests",
+	                        "Simple functionality tests",
+	"""
+	There is currently just one test for this library. It is a simple test that
+	uses the various format specifiers and checks the output.
+	""")
 
-resources = xmostest.request_resource("xsim")
+	resources = xmostest.request_resource("xsim")
 
-tester = xmostest.ComparisonTester(open('test.expect'),
-                                   'lib_logging', 'simple_tests',
-                                   'basic_functionality_test', {})
+	tester = xmostest.ComparisonTester(open('test.expect'),
+	                                   'lib_logging', 'simple_tests',
+	                                   'basic_functionality_test', {})
 
-xmostest.run_on_simulator(resources['xsim'],
-                          'debug_printf_test/bin/debug_printf_test.xe',
-                          tester=tester)
+	xmostest.run_on_simulator(resources['xsim'],
+	                          'debug_printf_test/bin/debug_printf_test.xe',
+	                          tester=tester)
 
-xmostest.finish()
+	xmostest.finish()


### PR DESCRIPTION
On windows, subprocess cannot fork from the system so it creates a new python instance and reimports everything. This stops it recursively calling itself