### PR TITLE
Sync buildsystems

### DIFF
--- a/lib_logging/module_build_info
+++ b/lib_logging/module_build_info
@@ -1,5 +1,7 @@
 OPTIONAL_HEADERS += debug_conf.h
 
+INCLUDE_DIRS = api
+
 MODULE_XCC_FLAGS = $(XCC_FLAGS) -Os
 
 VERSION = 2.1.1

--- a/lib_logging/wscript
+++ b/lib_logging/wscript
@@ -1,8 +1,94 @@
+import os.path
+
+
+def create_list_from_make_flag(bld, list_of_flags):
+    for i, flag in enumerate(list_of_flags):
+        if flag.startswith('$('):
+            for f in bld.env[flag.strip('$()')]:
+                list_of_flags.insert(i, f)
+                i += 1
+            list_of_flags.remove(flag)
+    return list_of_flags
+
+
+def create_list_of_strings(whitespace_seperated_list):
+    list_of_strings = whitespace_seperated_list.split(' ')
+    for item in list_of_strings:
+        item = "'{}'".format(item)
+    return list_of_strings
+
+
+def read_module_build_info(bld):
+    with open(os.path.join(bld.path.abspath(), 'module_build_info')) as file:
+        module_build_info = {}
+        for line in file.readlines():
+            line = line.strip()
+            if line and not line.startswith('#'):
+                key, value = line.split('=', 1)
+                module_build_info[key.strip(' +')] = value.strip()
+
+        try:
+            module_build_info['OPTIONAL_HEADERS'] = (
+                create_list_of_strings(module_build_info['OPTIONAL_HEADERS']))
+        except KeyError:
+            pass
+
+        try:
+            module_build_info['DEPENDENT_MODULES'] = (
+                create_list_of_strings(module_build_info['DEPENDENT_MODULES']))
+        except KeyError:
+            pass
+
+        try:
+            module_build_info['MODULE_XCC_FLAGS'] = (
+                create_list_from_make_flag(bld,
+                    create_list_of_strings(module_build_info['MODULE_XCC_FLAGS'])))
+        except KeyError:
+            pass
+
+        try:
+            module_build_info['MODULE_XCC_XC_FLAGS'] = (
+                create_list_from_make_flag(bld,
+                    create_list_of_strings(module_build_info['MODULE_XCC_XC_FLAGS'])))
+        except KeyError:
+            pass
+
+        try:
+            module_build_info['MODULE_XCC_C_FLAGS'] = (
+                create_list_from_make_flag(bld,
+                    create_list_of_strings(module_build_info['MODULE_XCC_C_FLAGS'])))
+        except KeyError:
+            pass
+
+        try:
+            module_build_info['MODULE_XCC_CPP_FLAGS'] = (
+                create_list_from_make_flag(bld,
+                    create_list_of_strings(module_build_info['MODULE_XCC_CPP_FLAGS'])))
+        except KeyError:
+            pass
+
+        try:
+            module_build_info['MODULE_XCC_ASM_FLAGS'] = (
+                create_list_from_make_flag(bld,
+                    create_list_of_strings(module_build_info['MODULE_XCC_ASM_FLAGS'])))
+        except KeyError:
+            pass
+
+        try:
+            module_build_info['INCLUDE_DIRS'] = (
+                create_list_of_strings(module_build_info['INCLUDE_DIRS']))
+        except KeyError:
+            pass
+
+        return module_build_info
+
+
 def use_module(bld):
+    module_build_info = read_module_build_info(bld)
     sources = bld.path.ant_glob('src/*.c')
     bld.env.MODULE_XCC_FLAGS = bld.env.XCC_FLAGS + ['-Os']
     bld.module(
         source=sources,
-        includes='api',
-        optional_headers='debug_conf.h',
-        version='2.1.0')
+        includes=module_build_info['INCLUDE_DIRS'],
+        optional_headers=module_build_info['OPTIONAL_HEADERS'],
+        version=module_build_info['VERSION'])


### PR DESCRIPTION
To ensure xwaf and xmake builds of the library use the same values, the `wscript` now uses the `module_build_info` where possible.