### PR TITLE
Clean up python setup file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,9 @@ import setuptools
 # The same modules should appear in the requirements.txt file as given below.
 setuptools.setup(
     name='lib_logging',
-    package_dir={'': 'lib/python'},
-    packages=setuptools.find_packages(where="lib/python"),
     install_requires=[
         "flake8~=3.8",
+    ],
+    dependency_links=[
     ],
 )


### PR DESCRIPTION
Remove arguments with incorrect path.  Add empty dependency_links argument.

The setup function assumes the current directory as the default for packages, which is correct for lib_logging.  The empty dependency_links list makes all setup.py files similar in content.