### PR TITLE
Feature/update xjsl version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('xmos_jenkins_shared_library@test/infr_venvs_plus_warnings') _
+@Library('xmos_jenkins_shared_library@v0.14.2') _
 
 getApproval()
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('xmos_jenkins_shared_library@v0.14.1') _
+@Library('xmos_jenkins_shared_library@feature/warnings_plugin_deprecation') _
 
 getApproval()
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('xmos_jenkins_shared_library@feature/warnings_plugin_deprecation') _
+@Library('xmos_jenkins_shared_library@test/infr_venvs_plus_warnings') _
 
 getApproval()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,5 +30,3 @@ flake8==3.8.3
 # If this repository uses the setup functionality (e.g., script entry points)
 # of its own setup.py file, then this list must include an entry for that
 # setup.py file, e.g., '-e .' or '-e ./python' (without the quotes).
--e ../infr_scripts_py
--e ../infr_apps

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,5 @@ flake8==3.8.3
 # If this repository uses the setup functionality (e.g., script entry points)
 # of its own setup.py file, then this list must include an entry for that
 # setup.py file, e.g., '-e .' or '-e ./python' (without the quotes).
+-e ../infr_apps
+-e ../infr_scripts_py

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,5 +30,5 @@ flake8==3.8.3
 # If this repository uses the setup functionality (e.g., script entry points)
 # of its own setup.py file, then this list must include an entry for that
 # setup.py file, e.g., '-e .' or '-e ./python' (without the quotes).
--e ../infr_apps
 -e ../infr_scripts_py
+-e ../infr_apps


### PR DESCRIPTION
Test PR to check new warnings plugin syntax in flake8 step of xjsl.

https://github.com/jenkinsci/warnings-ng-plugin

And remove infr venvs and include them as repo dependencies.
