### PR TITLE
Re-apply original copyright years

### DIFF
--- a/examples/AN00239/src/main.xc
+++ b/examples/AN00239/src/main.xc
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 XMOS LIMITED.
+// Copyright 2014-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #include "debug_print.h"

--- a/examples/AN00239/src/unit.xc
+++ b/examples/AN00239/src/unit.xc
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 XMOS LIMITED.
+// Copyright 2014-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #define DEBUG_UNIT unit


### PR DESCRIPTION
The fixed infr_apps source checker can handle copyright dates that predate the git history, so re-apply the original copyright years.