### PR TITLE
Use xtagctl to reset xcore-ai boards

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,25 +90,27 @@ pipeline {
           steps {
             sh '/XMOS/get_tools.py ' + params.TOOLS_VERSION
             installDependencies()
-            withVenv {
-              sh 'pip install git+git://github0.xmos.com/xmos-int/xtagctl.git@v1.3.1'
-              sh 'xtagctl reset_all XCORE-AI-EXPLORER'
-            }
           }
         }
         stage('xrun'){
           steps{
             toolsEnv(TOOLS_PATH) {  // load xmos tools
-              //Run this and diff against expected output. Note we have the lib files here available
-              unstash 'debug_printf_test'
-              sh 'xrun --io --id 0 bin/xcoreai/debug_printf_test.xe &> debug_printf_test.txt'
-              sh 'cat debug_printf_test.txt && diff debug_printf_test.txt tests/test.expect'
+              withVenv {  // activate virtualenv
+                //Install xtagctl and reset xtags
+                sh 'pip install git+git://github0.xmos.com/xmos-int/xtagctl.git@v1.3.1'
+                sh 'xtagctl reset_all XCORE-AI-EXPLORER'
 
-              //Just run these and error on exception
-              unstash 'AN00239'
-              sh 'xrun --io --id 0 bin/xcoreai/AN00239.xe'
-              unstash 'app_debug_printf'
-              sh 'xrun --io --id 0 bin/xcoreai/app_debug_printf.xe'
+                //Run this and diff against expected output. Note we have the lib files here available
+                unstash 'debug_printf_test'
+                sh 'xrun --io --id 0 bin/xcoreai/debug_printf_test.xe &> debug_printf_test.txt'
+                sh 'cat debug_printf_test.txt && diff debug_printf_test.txt tests/test.expect'
+
+                //Just run these and error on exception
+                unstash 'AN00239'
+                sh 'xrun --io --id 0 bin/xcoreai/AN00239.xe'
+                unstash 'app_debug_printf'
+                sh 'xrun --io --id 0 bin/xcoreai/app_debug_printf.xe'
+              }
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,7 +81,7 @@ pipeline {
         }
         stage('xrun'){
           steps{
-            dir("{REPO}") {
+            dir("${REPO}") {
               viewEnv {  // load xmos tools
                 withVenv {  // activate virtualenv
                   //Install xtagctl and reset xtags

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,25 +4,17 @@ getApproval()
 
 pipeline {
   agent none
-  //Tools for AI verif stage. Tools for standard stage in view file
-  parameters {
-    string(
-      name: 'TOOLS_VERSION',
-      defaultValue: '15.0.5',
-      description: 'The tools version to build with (check /projects/tools/ReleasesTools/)'
-    )
+  environment {
+    REPO = 'lib_logging'
+    VIEW = getViewName(REPO)
+  }
+  options {
+    skipDefaultCheckout()
   }
   stages {
     stage('Standard build and XS2 tests') {
       agent {
         label 'x86_64&&brew'
-      }
-      environment {
-        REPO = 'lib_logging'
-        VIEW = getViewName(REPO)
-      }
-      options {
-        skipDefaultCheckout()
       }
       stages{
         stage('Get view') {
@@ -81,35 +73,32 @@ pipeline {
       agent {
         label 'xcore.ai-explorer'
       }
-      environment {
-        // '/XMOS/tools' from get_tools.py and rest from tools installers
-        TOOLS_PATH = "/XMOS/tools/${params.TOOLS_VERSION}/XMOS/XTC/${params.TOOLS_VERSION}"
-      }
       stages{
-        stage('Install Dependencies') {
+        stage('Get view') {
           steps {
-            sh '/XMOS/get_tools.py ' + params.TOOLS_VERSION
-            installDependencies()
+            xcorePrepareSandbox("${VIEW}", "${REPO}")
           }
         }
         stage('xrun'){
           steps{
-            toolsEnv(TOOLS_PATH) {  // load xmos tools
-              withVenv {  // activate virtualenv
-                //Install xtagctl and reset xtags
-                sh 'pip install git+git://github0.xmos.com/xmos-int/xtagctl.git@v1.3.1'
-                sh 'xtagctl reset_all XCORE-AI-EXPLORER'
+            dir("{REPO}") {
+              viewEnv {  // load xmos tools
+                withVenv {  // activate virtualenv
+                  //Install xtagctl and reset xtags
+                  sh "pip install -e ${WORKSPACE}/xtagctl"
+                  sh 'xtagctl reset_all XCORE-AI-EXPLORER'
 
-                //Run this and diff against expected output. Note we have the lib files here available
-                unstash 'debug_printf_test'
-                sh 'xrun --io --id 0 bin/xcoreai/debug_printf_test.xe &> debug_printf_test.txt'
-                sh 'cat debug_printf_test.txt && diff debug_printf_test.txt tests/test.expect'
+                  //Run this and diff against expected output. Note we have the lib files here available
+                  unstash 'debug_printf_test'
+                  sh 'xrun --io --id 0 bin/xcoreai/debug_printf_test.xe &> debug_printf_test.txt'
+                  sh 'cat debug_printf_test.txt && diff debug_printf_test.txt tests/test.expect'
 
-                //Just run these and error on exception
-                unstash 'AN00239'
-                sh 'xrun --io --id 0 bin/xcoreai/AN00239.xe'
-                unstash 'app_debug_printf'
-                sh 'xrun --io --id 0 bin/xcoreai/app_debug_printf.xe'
+                  //Just run these and error on exception
+                  unstash 'AN00239'
+                  sh 'xrun --io --id 0 bin/xcoreai/AN00239.xe'
+                  unstash 'app_debug_printf'
+                  sh 'xrun --io --id 0 bin/xcoreai/app_debug_printf.xe'
+                }
               }
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
   parameters {
     string(
       name: 'TOOLS_VERSION',
-      defaultValue: '15.0.2',
+      defaultValue: '15.0.5',
       description: 'The tools version to build with (check /projects/tools/ReleasesTools/)'
     )
   }
@@ -83,7 +83,7 @@ pipeline {
       }
       environment {
         // '/XMOS/tools' from get_tools.py and rest from tools installers
-        TOOLS_PATH = "/XMOS/tools/${params.TOOLS_VERSION}/XMOS/xTIMEcomposer/${params.TOOLS_VERSION}"
+        TOOLS_PATH = "/XMOS/tools/${params.TOOLS_VERSION}/XMOS/XTC/${params.TOOLS_VERSION}"
       }
       stages{
         stage('Install Dependencies') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,6 +90,10 @@ pipeline {
           steps {
             sh '/XMOS/get_tools.py ' + params.TOOLS_VERSION
             installDependencies()
+            withVenv {
+              sh 'pip install git+git://github0.xmos.com/xmos-int/xtagctl.git@v1.3.1'
+              sh 'xtagctl reset_all XCORE-AI-EXPLORER'
+            }
           }
         }
         stage('xrun'){


### PR DESCRIPTION
Hoping to fix failures such as those seen here: http://srv-bri-jcim0:8080/blue/organizations/jenkins/XMOS%2Flib_logging/detail/develop/644/

The test is now outputting an extra warning about resetting the xtag which is failing the test as this is not in the expected output. 

Hopefully, resetting the xtag manually before any tests are run should eliminate this extra message.

I elected to pip install straight from the github0 url as opposed to putting it in the viewfile as we don't actually check out the view on the xcore.ai agents.