### PR TITLE
Add XS compatibility coverage for lib_logging

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,6 +74,7 @@ pipeline {
               xcoreBuild(
                 toolsVersion: params.TOOLS_VERSION_XS,
                 buildDir: 'build-xs',
+                cmakeOpts: '-DLOGGING_BUILD_XC_TESTS=ON',
                 archiveBins: false
               )
               withTools(params.TOOLS_VERSION_XS) {
@@ -104,13 +105,13 @@ pipeline {
               xcoreBuild(
                 toolsVersion: params.TOOLS_VERSION_VX,
                 buildDir: 'build-vx',
-                cmakeOpts: '-DAPP_HW_TARGET=XK-EVK-XU416',
+                cmakeOpts: '-DAPP_HW_TARGET=XK-EVK-XU416 -DLOGGING_BUILD_XC_TESTS=OFF',
                 archiveBins: false
               )
               withTools(params.TOOLS_VERSION_VX) {
                 createVenv(reqFile: 'requirements.txt')
                 withVenv {
-                  runPytest()
+                  runPytest('--ignore=test_lib_logging_xc.py')
                 }
               }
             }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,4 +2,11 @@ cmake_minimum_required(VERSION 3.21)
 include($ENV{XMOS_CMAKE_PATH}/xcommon.cmake)
 project(tests)
 
+# XC sources require the XS/XTC 15 toolchain and cannot be built for VX targets.
+option(LOGGING_BUILD_XC_TESTS "Build XS-only XC compatibility tests" OFF)
+
 add_subdirectory(debug_printf_test)
+
+if(LOGGING_BUILD_XC_TESTS)
+  add_subdirectory(debug_printf_xc_test)
+endif()

--- a/tests/debug_printf_xc_test/CMakeLists.txt
+++ b/tests/debug_printf_xc_test/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.21)
+include($ENV{XMOS_CMAKE_PATH}/xcommon.cmake)
+project(debug_printf_xc_test)
+
+if(NOT DEFINED APP_HW_TARGET)
+  set(APP_HW_TARGET XK-EVK-XU316)
+endif()
+
+set(APP_COMPILER_FLAGS -DDEBUG_PRINT_ENABLE=1)
+
+include(${CMAKE_CURRENT_LIST_DIR}/../../examples/deps.cmake)
+set(XMOS_SANDBOX_DIR ${CMAKE_CURRENT_LIST_DIR}/../../..)
+
+XMOS_REGISTER_APP()

--- a/tests/debug_printf_xc_test/src/main.xc
+++ b/tests/debug_printf_xc_test/src/main.xc
@@ -1,0 +1,10 @@
+// Copyright 2026 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+#include <debug_print.h>
+
+int main(void)
+{
+    debug_printf("XC logging: %d\n", 42);
+    return 0;
+}

--- a/tests/test_lib_logging_xc.py
+++ b/tests/test_lib_logging_xc.py
@@ -1,0 +1,16 @@
+# Copyright 2026 XMOS LIMITED.
+# This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+import subprocess
+from pathlib import Path
+
+
+def test_lib_logging_from_xc():
+    test_dir = Path(__file__).parent
+    binary = test_dir / "debug_printf_xc_test" / "bin" / "debug_printf_xc_test.xe"
+    expected = (test_dir / "test_xc.expect").read_text()
+
+    result = subprocess.run(["xsim", str(binary)], capture_output=True, text=True)
+
+    assert result.returncode == 0
+    assert result.stdout == expected

--- a/tests/test_xc.expect
+++ b/tests/test_xc.expect
@@ -1,0 +1,1 @@
+XC logging: 42


### PR DESCRIPTION
Test debug printing from XC while keeping VX builds isolated, and depend on lib_basix for cross-architecture compatibility.